### PR TITLE
8_テキスト教材のrakeタスクを実装

### DIFF
--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,5 +1,2 @@
 class Text < ApplicationRecord
-  validates :genre, presence: true
-  validates :title, presence: true
-  validates :content, presence: true
 end

--- a/db/migrate/20201205125903_create_texts.rb
+++ b/db/migrate/20201205125903_create_texts.rb
@@ -1,9 +1,6 @@
 class CreateTexts < ActiveRecord::Migration[6.0]
   def change
     create_table :texts do |t|
-      t.string :genre
-      t.string :title
-      t.text :content
 
       t.timestamps
     end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -1,0 +1,29 @@
+require 'csv'
+
+namespace :import_csv do
+  desc "CSVデータをインポートするタスク"
+  task texts: :environment do
+    # インポートするファイルのパスを取得
+    path = "db/csv_data/csv_data.csv"
+    # インポートするデータを格納するための配列
+    list = []
+    # CSVファイルからインポートするデータを取得し配列に格納
+    CSV.foreach(path, headers: true) do |row|
+      list << row.to_h
+    end
+    puts "インポート処理を開始"
+    # インポートができなかった場合の例外処理
+    begin
+      User.create!(list)
+      puts "インポート完了!!"
+    rescue => e
+      # 例外が発生した場合の処理
+      # インポートができなかった場合の例外処理
+      puts "#{e.class}: #{e.message}"
+      puts "-------------------------"
+      puts e.backtrace # 例外が発生した位置情報
+      puts "-------------------------"
+      puts "インポートに失敗"
+    end
+  end
+end


### PR DESCRIPTION
## 実装内容
- textモデル作成(カラム設定なし)
- import_csvタスク作成
- import_csv.rakeに処理記載
- csv_dataフォルダ作成
- csv_data.csvファイル作成

## チェックリスト
- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）


## 備考（必要があれば）
textモデル作成の際に、「rails g model Text」にて以下警告が出たため、「rails g model Text --force」を実行しました
```
Running via Spring preloader in process 14125
      invoke  active_record
The name 'Text' is either already used in your application or reserved by Ruby on Rails. Please choose an alternative or use --force to skip this check and run this generator again.
```