### PR TITLE
15_Railsテキスト教材一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,3 +35,8 @@ h1.sign-in {
 .navbar {
   background: #6699FF;
 }
+
+/* テキスト教材一覧ページ */
+.card-body {
+height: 175px
+}

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,5 +1,5 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.order(id: :asc)
+    @texts = Text.recent
   end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,5 +1,5 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.recent
+    @texts = Text.id_sorted_only_specific_genre
   end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,4 +1,5 @@
 class TextsController < ApplicationController
   def index
+    @texts = Text.order(id: :asc)
   end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -5,5 +5,5 @@ class Text < ApplicationRecord
 
   scope :specific_genre, -> { where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]) }
   scope :sorted, -> { order(id: :asc) }
-  scope :recent, -> { specific_genre.sorted }
+  scope :id_sorted_only_specific_genre, -> { specific_genre.sorted }
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -2,4 +2,8 @@ class Text < ApplicationRecord
   validates :genre, presence: true
   validates :title, presence: true
   validates :content, presence: true
+
+  scope :specific_genre, -> { where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]) }
+  scope :sorted, -> { order(id: :asc) }
+  scope :recent, -> { specific_genre.sorted }
 end

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,2 +1,30 @@
-<h1>トップページ</h1>
-<p>テキスト教材を表示する画面です</p>
+<div class="base-container mw-xl">
+  <div class="texts-wrapper">
+    <div class="contents-title text-center">
+      <h1>テキスト教材</h1>
+    </div>
+
+    <div class="row">
+      <% @texts.each do |text| %>
+        <div class="col-12 col-md-6 col-lg-4 text-card-container">
+          <div class="card content-card border-dark mb-3">
+            <a target="_blank" href="/texts/<%= text.id %>">
+              <div class="card-header p-0">
+                <img loading="lazy" alt="<%= text.title %>" class="img-fluid" src="https://trello-attachments.s3.amazonaws.com/5e65d7fe7e526f7060e27480/5fbf3f36bf714b2cddb82681/x/3af2293df5cad71e0745f06ed650acb1/no_image.jpg">
+              </div>
+              <div class="card-body text-dark text-card-body">
+                <div id="read-text-<%= text.id %>">
+
+                </div>
+                <p class="card-text text-title">
+                  <%= text.title %>
+                </p>
+                <p>【<%= text.genre %>】</p>
+              </div>
+            </a>
+          </div>
+        </div>
+      <% end %>  
+    </div>
+  </div>
+    </div>


### PR DESCRIPTION
## 実装内容
-  Railsテキスト教材の一覧ページを作成
- ジャンルによる表示出し分け

## 未着手
- ナビバーのリンク
「10_ナビバーの実装」にてすでに実装されているかと思いました。(間違っておりましたら、お申し付けください)

## 質問
cssについて、「texts.scss」が反応しない原因と対策をご教示いただけますでしょうか。
[こちらの記事](https://qiita.com/kentalpsw/items/6576a872f6209a712ef8)を参考に「*= require_selfと*=require_tree」を記載してみましたが、エラーが出たため、ひとまずapplication.scssに記載した次第です。