### PR TITLE
(0.5) bug_fix_スタイル崩れの修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,10 @@
 /* 全体 */
+
+/*
+ *= require_tree .
+ *= require_self
+ */
+
 @import "bootstrap/scss/bootstrap";
 
 $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
@@ -30,35 +36,29 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 
 .alert-alert {
   @extend .alert-danger;
+}
 
 
+.mw-md {
+  max-width: 576px;
+}
 
-  .mw-md {
-    max-width: 576px;
-  }
 
+/* ログイン画面 */
 
-  /* ログイン画面 */
+h1.sign-in {
+  text-align: center;
+}
 
-  h1.sign-in {
-    text-align: center;
-  }
+/* nav-itemの文字色 */
+.navbar .navbar-nav .nav-link {
+  color: #FFFFFF;
+}
 
-  /* nav-itemの文字色 */
-  .navbar .navbar-nav .nav-link {
-    color: #FFFFFF;
-  }
+.navbar .navbar-brand {
+  color: #FFFFFF;
+}
 
-  .navbar .navbar-brand {
-    color: #FFFFFF;
-  }
-
-  .navbar {
-    background: #6699FF;
-  }
-
-  /* テキスト教材一覧ページ */
-  .card-body {
-    height: 175px
-  }
+.navbar {
+  background-color: #6699FF;
 }

--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -1,3 +1,7 @@
 // Place all the styles related to the texts controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+  .card-body {
+    height: 175px
+  }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -21,8 +21,6 @@
               <a class="dropdown-item" href="#">チャレンジ問題集</a>
             </div>
           </li>
-          <ul class="navbar-nav">
-
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             PHP
@@ -30,11 +28,9 @@
             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
               <a class="dropdown-item" href="#">PHPテキスト教材</a>
               <a class="dropdown-item" href="#">PHP動画教材</a>
-              
             </div>
           </li>
-          
-          
+
           <li class="nav-item">
             <a class="nav-link" href="#">対談</a>
           </li>
@@ -55,7 +51,7 @@
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link"＞<%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
+            <a class="nav-item nav-link" rel="nofollow" data-method="delete" href="/users/sign_out">ログアウト</a>
           </li>
         </ul>
       </div>
@@ -97,10 +93,10 @@
             <a class="nav-link" href="#">LINE</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link"＞<%= link_to "新規登録", new_user_registration_path %>
+            <a class="nav-item nav-link" href="/users/sign_up">新規登録</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link"＞<%= link_to "ログイン", new_user_session_path %>
+            <a class="nav-item nav-link" href="/users/sign_in">ログイン</a>
           </li>
 
         </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,14 +11,6 @@
   </head>
 
   <body>    
-    <% if user_signed_in? %>
-      <%# ログイン時 %>
-      <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
-    <% else %>
-      <%# 非ログイン時 %>
-      <%= link_to "新規登録", new_user_registration_path %>
-      <%= link_to "ログイン", new_user_session_path %>
-    <% end %>
     <header>
       <%= render 'layouts/header' %>
     </header>


### PR DESCRIPTION
## 実装内容
- application.html.erbにて、ログイン、新規登録、ログアウトのリンク削除
- application.scssにて、ヘッダーにcssが当たらない問題を修正
  - 閉じタグの位置が原因でした
- _header.html.erbにて、ログイン、新規登録、ログアウトのリンク修正
  -  例えば「<a class="nav-link"＞<%= link_to "新規登録", new_user_registration_path %>」の部分のaタグの閉じカッコが全角となっておりました。半角に戻すとなぜかcssが効かなくなったため、逆転教材の当該ページをデベロッパーツールで表示し、記載をコピーしました。

## チェックリスト

※ プルリクを出した後にクリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
